### PR TITLE
Change link to the definition of HTMLOr*Element from HTML5

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
           <p>The
             <dfn data-cite="HTML#globaleventhandlers"><code>GlobalEventHandlers</code></dfn>,
             <dfn data-cite="HTML#documentandelementeventhandlers"><code>DocumentAndElementEventHandlers</code></dfn> and
-            <dfn data-cite="HTML#htmlorsvgelement"><code>HTMLOrForeignElement</code></dfn> interfaces are defined in
+            <dfn data-cite="HTML#htmlorforeignelement"><code>HTMLOrForeignElement</code></dfn> interfaces are defined in
             [[HTML]].</p>
           <p>The
             <dfn data-cite="CSSOM#elementcssinlinestyle"><code>ElementCSSInlineStyle</code></dfn>


### PR DESCRIPTION
s/HTMLOrSVGElement/HTMLOrForeignElement/

This was requested on https://github.com/whatwg/html/pull/4893 but we need to wait for the HTML change.