### PR TITLE
Revert "Change link to the definition of HTMLOr*Element from HTML5"

### DIFF
--- a/index.html
+++ b/index.html
@@ -796,7 +796,7 @@
           <p>The
             <dfn data-cite="HTML#globaleventhandlers"><code>GlobalEventHandlers</code></dfn>,
             <dfn data-cite="HTML#documentandelementeventhandlers"><code>DocumentAndElementEventHandlers</code></dfn> and
-            <dfn data-cite="HTML#htmlorforeignelement"><code>HTMLOrForeignElement</code></dfn> interfaces are defined in
+            <dfn data-cite="HTML#htmlorsvgelement"><code>HTMLOrForeignElement</code></dfn> interfaces are defined in
             [[HTML]].</p>
           <p>Each IDL attribute of the
             <a><code>MathMLElement</code></a> interface


### PR DESCRIPTION
Reverts w3c/mathml-core#19