### PR TITLE
remove boilerplate text that is duplicating respec

### DIFF
--- a/index.html
+++ b/index.html
@@ -6035,18 +6035,6 @@
       </p>
     </section>
     <section id="conformance" class="appendix normative">
-      <h2>Conformance</h2>
-      <section>
-        <h3>Document conventions</h3>
-        <p>
-          Conformance requirements are expressed with a combination of
-          descriptive assertions and RFC 2119 terminology. The key words “MUST”,
-          “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
-          “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
-          document are to be interpreted as described in RFC 2119.
-          However, for readability, these words do not appear in all uppercase
-          letters in this specification.
-        </p>
         <p>
           All of the text of this specification is normative except sections
           explicitly marked as non-normative, examples, and notes.
@@ -6075,7 +6063,6 @@
           <code>&lt;strong class="advisement"&gt;</code>, like this:
           <strong class="advisement">UAs MUST provide an accessible alternative. </strong>
         </p>
-      </section>
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6034,7 +6034,17 @@
         available and preferred math fonts for a user.
       </p>
     </section>
-    <section id="conformance" class="appendix normative">
+    <section id="conformance" class="appendix normative override">
+      <h2>Conformance</h2>
+        <p>
+          Conformance requirements are expressed with a combination of
+          descriptive assertions and RFC 2119 terminology. The key words “MUST”,
+          “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
+          “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
+          document are to be interpreted as described in RFC 2119.
+          However, for readability, these words do not appear in all uppercase
+          letters in this specification.
+        </p>
         <p>
           All of the text of this specification is normative except sections
           explicitly marked as non-normative, examples, and notes.


### PR DESCRIPTION
The **Conformance** heading and first para re MAY, MUST have been duplicated since we switched to respec as respec has special handling for `id="conformance` and adds a heading and this paragraph.

This PR <strike>deletes the text and lets respec add it.</strike> prevents respec duplicating the text using its `override` class.