### PR TITLE
WIP: Use wpt.fyi data instead of Igalia servers

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 	  github: "w3c/mathml-core",
           mdn: false,
           testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/mathml/",
-          implementationReportURI: "https://wpt.fyi/results/?label=master&label=experimental&aligned&q=mathml",
+          implementationReportURI: "https://wpt.fyi/results/?label=master&label=experimental&aligned&q=math%20%20not%28path%3A%2Fjs%29",
 	  
           localBiblio: {
               "MATHML4": {

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 	  github: "w3c/mathml-core",
           mdn: false,
           testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/mathml/",
-          implementationReportURI: "https://w3c.github.io/mathml-core/implementation-report.html",
+          implementationReportURI: "https://wpt.fyi/results/?label=master&label=experimental&aligned&q=mathml",
 	  
           localBiblio: {
               "MATHML4": {

--- a/spec-implementation-report.js
+++ b/spec-implementation-report.js
@@ -11,7 +11,7 @@ let wptDataPromise = async function () {
     let data = await f.json();
     let ids = data.map(rec => rec.id).join();
 
-    // Note: this will get a bit "too much", but it doesn't matter 
+    // Note: this may get a bit "too much", but it doesn't matter to results
     f = await fetch(`https://wpt.fyi/api/search?label=master&label=experimental&q=math&run_ids=${ids}`);
     data = await f.json();
 

--- a/spec-implementation-report.js
+++ b/spec-implementation-report.js
@@ -2,45 +2,40 @@
 /* vim: set ts=4 et sw=4 tw=80: */
 
 /*
-  Massage each engines data into a nice indexed
+  Get the latest aligned run data from WPT,
+  massage it into a nice indexed
   result set (testPath:result) for quick reference
 */
+let wptDataPromise = async function () {
+    let f = await fetch('https://wpt.fyi/api/runs?aligned');
+    let data = await f.json();
+    let ids = data.map(rec => rec.id).join();
 
+    // Note: this will get a bit "too much", but it doesn't matter 
+    f = await fetch(`https://wpt.fyi/api/search?label=master&label=experimental&q=math&run_ids=${ids}`);
+    data = await f.json();
 
-async function getBrowserWPTData(browser) {
-    let ret = {
-        engine: browser,
-        results: {}
-    }
-    let data = await fetchWebPlatformTestResults(browser);
-    data.results.forEach(item => {
-      if (item.status === "OK") {
-          // Check all the subtests.
-          item.status = "FAIL";
-          if (item.subtests && item.subtests.length > 0) {
-              item.status = "PASS";
-              for (i in item.subtests) {
-                  if (item.subtests[i].status !== "PASS") {
-                      item.status = "FAIL";
-                      break;
-                  }
-              }
-          }
-      }
-      ret.results[item.test] = item.status;
-    })
-    return ret
-}
+    return data.runs.map((run, i) => {
+        let retVal = {
+            engine: run.browser_name,
+            results: {}
+        };
 
-/*
-  We can launch these early and get data
-*/
-let wptDataPromise = Promise.all([
-//    getBrowserWPTData('blink'),
-    getBrowserWPTData('chrome'),
-    getBrowserWPTData('firefox'),
-    getBrowserWPTData('safari')
-])
+        data.results.forEach((item) => {
+            retVal.results[item.test] = (
+                item.legacy_status[i].passes
+                ==
+                item.legacy_status[i].total
+                )
+                ?
+                "PASS"
+                :
+                "FAIL";
+
+       })
+       return retVal;
+    });
+}();
 
 /*
   Before we start, re-attach
@@ -83,7 +78,7 @@ async function loadWebPlaformTestsResults() {
     let ENGINE_LOGOS = {
         'firefox': "https://test.csswg.org/harness/img/gecko.svg",
         'safari': "https://test.csswg.org/harness/img/webkit.svg",
-        //        'blink': "https://pbs.twimg.com/profile_images/1576817016/igalia_400x400.png",
+        'edge': "https://test.csswg.org/harness/img/edge.svg",
         'chrome': "https://test.csswg.org/harness/img/blink.svg",
     };
 
@@ -143,7 +138,7 @@ async function loadWebPlaformTestsResults() {
         let frag = document.createRange().createContextualFragment(source);
         annotationEl.appendChild(frag);
 
-    });
 
+    });
     document.getElementById("implementation-report").insertAdjacentHTML("beforeend", `<div style="margin-left: 2em; margin-right: 2em"><a href="${respecConfig.implementationReportURI}">Implementation Report</a></div>`);
 }


### PR DESCRIPTION
Addresses #119 when we're sure about it.  Marking it as WIP so that it isn't prematurely merged because at a minimum I'd like to point out the less than perfect bits here.

As discussed in the meeting yesterday, we've switched to using a wpt.fyi URL for the implementation report, and since our tests (depending on how you look at it) encompass a lot of directories we're using a query.  To be clear, that's "fine".  What is a bit wonky though is that the search is a little fuzzy and this means we're going to be imperfect in one way or another, and this impacts both the implementation report and the annotations in different ways.

If we use [math](https://wpt.fyi/results/?label=master&label=experimental&aligned&q=math) you'll see we pick up the tests about the global JS Math object and CSS TypedOM math too. It's not many tests, but a little confusing.  If we use [mathml](https://wpt.fyi/results/?label=master&label=experimental&aligned&q=mathml) then we leave off ~55 tests about CSS integrations.  Now, _many_ of those (I didn't scrutinize closely) are about things like text-transforms which I'm not entirely sure about. Neither option is perfect from that point of view.  However, we also have to load the wpt data with a query, and there it matches up the annotations in the spec itself - so requesting slightly more is actually better - we wind up with tests that match up for everything. If we don't, we wind up with tests that don't match up.

I guess what I am suggesting here is that we should review the tests and annotations in the spec and consider whether we can add a label or adjust some names or something too to make this better.
