### PR TITLE
auto-publish.yml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,25 @@
+# https://w3c.github.io/spec-prod/#examples
+# Create a file called .github/workflows/auto-publish.yml
+name: CI
+on:
+  push:
+    branches: [main]
+jobs:
+  main:
+    name: Deploy to GitHub pages
+    runs-on: ubuntu-20.04
+    steps:
+     - uses: actions/checkout@v2
+     - run: |
+          git fetch
+          git checkout gh-pages
+          git reset main --hard
+          git push -f
+     - uses: w3c/spec-prod@v2
+       with:
+          GH_PAGES_BRANCH: gh-pages
+          TOOLCHAIN: respec
+          SOURCE: index.html
+          DESTINATION: spec.html
+          VALIDATE_MARKUP: true
+


### PR DESCRIPTION
This PR makes no changes to the spec but enables a github action to leave an exported respec snapshot as `spec.html` in addition to the existing "live" respec source as `index.html` 

For discussion of this see the issue at the main MathML4 repo w3c/mathml#329