### PR TITLE
Move the 'none' element into a separate subsection

### DIFF
--- a/examples/example-mmultiscripts.html
+++ b/examples/example-mmultiscripts.html
@@ -3,11 +3,11 @@
     <mn>1</mn>
     <mn>2</mn>
     <mn>3</mn>
-    <none/>
+    <mrow></mrow>
     <mn>5</mn>
     <mprescripts/>
     <mn>6</mn>
-    <none/>
+    <mrow></mrow>
     <mn>8</mn>
     <mn>9</mn>
   </mmultiscripts>

--- a/index.html
+++ b/index.html
@@ -4111,21 +4111,18 @@
           <h4>Prescripts and Tensor Indices <code>&lt;mmultiscripts&gt;</code></h4>
           <p>
             Presubscripts and tensor notations are represented by
-            the <dfn><code>&lt;mmultiscripts&gt;</code></dfn>
-            with hints given by the
-            <dfn><code>&lt;mprescripts&gt;</code></dfn>
-            (to distinguish postscripts and prescripts)
-            and
-            <dfn><code>&lt;none&gt;</code></dfn> elements
-            (to indicate empty scripts).
-            These elements accept the attributes described in
+            the <dfn><code>&lt;mmultiscripts&gt;</code></dfn> element.
+            The <dfn><code>&lt;mprescripts&gt;</code></dfn> element is
+            used as a separator between the postscripts and prescripts.
+            These two elements accept the attributes described in
             <a href="#global-attributes"></a>.
           </p>
           <div class="example" id="mmultiscripts-example">
             <p>
               The following example shows basic use of prescripts
-              and postscripts, involving
-              <a>&lt;none&gt;</a> and <a>&lt;mprescripts&gt;</a>.
+              and postscripts involving a <a>&lt;mprescripts&gt;</a>.
+              Empty <a>&lt;mrow&gt;</a> elements are used at positions where
+              no scripts are rendered.
               The font-size is automatically scaled down within the scripts.
             </p>
             <pre data-include="examples/example-mmultiscripts.html"
@@ -4135,8 +4132,7 @@
           <p>
             If the
             <code>&lt;mmultiscripts&gt;</code>,
-            <code>&lt;mprescripts&gt;</code> or
-            <code>&lt;none&gt;</code> elements do not have their
+            <code>&lt;mprescripts&gt;</code> elements do not have their
             computed
             <a><code>display</code> property</a> equal to <code>block math</code>
             or <code>inline math</code>
@@ -4145,9 +4141,9 @@
             Otherwise, the layout below is performed.
           </p>
           <p>
-            The empty
-            <code>&lt;mprescripts&gt;</code> and <code>&lt;none&gt;</code>
-            elements are laid out as an <a><code>&lt;mrow&gt;</code></a>
+            The
+            <code>&lt;mprescripts&gt;</code>
+            element is laid out as an <a><code>&lt;mrow&gt;</code></a>
             element.
           </p>
           <p>
@@ -4184,15 +4180,26 @@
             If an <code>&lt;mmultiscripts&gt;</code> element is not valid then
             it is laid out the same as the
             <a><code>&lt;mrow&gt;</code></a> element.
-            Otherwise the layout algorithm is explained below.
+            Otherwise the layout algorithm is performed as in
+            <a href="#base-with-prescripts-and-postscripts"></a>.
           </p>
-          <div class="note">
-            The <code>&lt;none&gt;</code> element is preserved for backward
-            compatibility reasons but is actually not taken into account
-            in the layout algorithm.
-          </div>
           <section>
-            <h5>Base with prescripts and postscripts</h5>
+            <h5>The &lt;none&gt; element</h5>
+            <p>The <dfn><code>&lt;none&gt;</code></dfn> element
+              may be used to represent an empty script in
+              a <a>&lt;mmultiscripts&gt;</a> element.
+              It accepts the attributes described in
+              <a href="#global-attributes"></a> and is laid out the same as the
+              <a><code>&lt;mrow&gt;</code></a> element.
+            </p>
+            <div class="note">
+              The <code>&lt;none&gt;</code> element is preserved for backward
+              compatibility reasons. Authors are encouraged to use an
+              empty <a>&lt;mrow&gt;</a> element instead.
+            </div>
+          </section>
+          <section>
+            <h5 id="base-with-prescripts-and-postscripts">Base with prescripts and postscripts</h5>
             <p>
               The <code>&lt;mmultiscripts&gt;</code> element is laid out as
               shown on <a href="#figure-box-mmultiscripts"></a>.


### PR DESCRIPTION
This makes clearer that `<none>` is not involved at all in the layout of `<mmultiscripts>`. The corresponding example relies on empty `<mrow>` elements instead. The note for `<none>` is tweaked too to recommend empty `<mrow>` elements.

https://github.com/w3c/mathml-core/issues/173