### PR TITLE
Specify how to handle width/height properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -2084,11 +2084,43 @@
             <dfn id="attribute-mspace-height" class="element-attr" data-dfn-for="mspace">height</dfn>,
             <dfn id="attribute-mspace-depth" class="element-attr" data-dfn-for="mspace">depth</dfn>, if present, must
             have a value that is a valid <a data-xref-type="css-type">&lt;length-percentage&gt;</a>.
-            An unspecified attribute, a percentage  value, or an invalid value
-            is interpreted as <code>0</code>.
-            If one of the requested values calculated is negative then it is
-            treated as <code>0</code>.
           </p>
+          <ul>
+            <li>
+              If the <code>width</code>
+              attribute is present, valid and not a percentage then
+              that attribute is used as a
+              <a data-cite="HTML/../#presentational-hints">presentational hint</a>
+              setting the element's
+              <a data-xref-type="css-property">width</a>
+              property to the corresponding value.
+            </li>
+            <li>
+              If the <code>height</code>
+              attribute is absent, invalid or a percentage then the requested
+              line-ascent is <code>0</code>.
+              Otherwise the requested line-ascent is the resolved
+              value of the <code>height</code> attribute, clamping
+              negative values to <code>0</code>.
+            </li>
+            <li>
+              If both the <code>height</code> and <code>depth</code> attributes
+              are present, valid and not a percentage then they are used as a
+              <a data-cite="HTML/../#presentational-hints">presentational hint</a>
+              setting the element's
+              <a data-xref-type="css-property">height</a>
+              property to the concatenation of the strings
+              "<code>calc(</code>", the <code>height</code> attribute value,
+              "<code> + </code>", the <code>depth</code> attribute value,
+              and "<code>)</code>".
+              If only one of these attributes is
+              present, valid and not a percentage then it is treated as a
+              <a data-cite="HTML/../#presentational-hints">presentational hint</a>
+              setting the element's
+              <a data-xref-type="css-property">height</a>
+              property to the corresponding value.
+            </li>
+          </ul>
           <div class="example" id="mspace-example">
             <p>In the following example, [^mspace^] is used to
               force spacing within the formula (a 1px blue border is
@@ -2107,12 +2139,14 @@
             Otherwise,
             the <code>&lt;mspace&gt;</code> element is laid out as shown on
             <a href="#figure-box-mspace"></a>.
-            The <a>min-content inline size</a> and
-            <a>max-content inline size</a> of the math content are
-            equal to the requested inline size.
-            The <a>inline size</a>, <a>line-ascent</a> and <a>line-descent</a> of the math content
-            are respectively
-            the requested inline size, line-ascent and line-descent.
+            The <a>min-content inline size</a>,
+            <a>max-content inline size</a> and <a>inline size</a> of the math
+            content are equal to the resolved value of the
+            <a data-xref-type="css-property">width</a> property.
+            The <a>block size</a> of the math content is equal to the resolved
+            value of the <a data-xref-type="css-property">height</a> property.
+            The <a>line-ascent</a> of the math content is equal to the
+            requested line-ascent determined above.
           </p>
           <figure id="figure-box-mspace">
             <img src="figures/mspacebox.svg">
@@ -3162,33 +3196,58 @@
               <a>generates an anonymous &lt;mrow&gt; box</a> called the
               <dfn>mpadded inner box</dfn> with parameters called
               inner inline size, inner <a>line-ascent</a> and inner line-descent.
+            </p>
+            <p>
               The requested <code>&lt;mpadded&gt;</code>
               parameters are determined as follows:
             </p>
             <ul class="algorithm">
-              <li>If the <code>width</code> (respectively <code>height</code>,
-                <code>depth</code>, <code>lspace</code>, <code>voffset</code>)
-                attribute is absent, invalid or a percentage
-                then the requested width
-                (respectively height, depth, lspace, voffset)
-                is the inner inline size
-                (respectively inner <a>line-ascent</a>, inner line-descent,
-                <code>0</code>,
-                <code>0</code>).
+              <li>
+                The requested width
+                is the resolved value of the
+                <a data-xref-type="css-property">width</a> property.
+                If the <code>width</code>
+                attribute is present, valid and not a percentage then
+                that attribute is used as a
+                <a data-cite="HTML/../#presentational-hints">presentational hint</a>
+                setting the element's
+                <a data-xref-type="css-property">width</a>
+                property to the corresponding value.
               </li>
-              <li>Otherwise the requested width
-                (respectively height, depth, lspace, voffset) is the resolved
-                value of the <code>width</code> attribute
-                (respectively <code>height</code>, <code>depth</code>,
-                <code>lspace</code>, <code>voffset</code> attributes).
-                If one of the requested width, depth, height or lspace values
-                is negative then it is treated as <code>0</code>.
+              <li>
+                If the <code>height</code>
+                attribute is absent, invalid or a percentage then the requested
+                height is the inner <a>line-ascent</a>.
+                Otherwise the requested height is the resolved
+                value of the <code>height</code> attribute, clamping
+                negative values to <code>0</code>.
+              </li>
+              <li>
+                If the <code>depth</code>
+                attribute is absent, invalid or a percentage then the requested
+                depth is the inner <a>line-ascent</a>.
+                Otherwise the requested depth is the resolved
+                value of the <code>depth</code> attribute, clamping
+                negative values to <code>0</code>.
+              </li>
+              <li>
+                If the <code>lspace</code>
+                attribute is absent, invalid or a percentage then the requested
+                lspace is 0. Otherwise the requested lspace is the resolved
+                value of the <code>lspace</code> attribute, clamping
+                negative values to <code>0</code>.
+              </li>
+              <li>
+                If the <code>voffset</code>
+                attribute is absent, invalid or a percentage then the requested
+                voffset is 0. Otherwise the requested voffset is the resolved
+                value of the <code>voffset</code> attribute.
+                <div class="note">
+                  Negative <code>voffset</code> values are not clamped to
+                  <code>0</code>.
+                </div>
               </li>
             </ul>
-            <div class="note">
-              Negative <code>voffset</code> values are not clamped to
-              <code>0</code>.
-            </div>
           </section>
           <section>
             <h5>Layout of <code>&lt;mpadded&gt;</code></h5>

--- a/index.html
+++ b/index.html
@@ -780,17 +780,6 @@
               is treated as <code>nowrap</code> on all MathML elements.
             </li>
             <li>
-              Sizes:
-              <code>width</code>,
-              <code>height</code>,
-              <code>inline-size</code> and
-              <code>block-size</code>
-              are treated as <code>auto</code> on elements
-              with computed display value
-              <a href="#new-display-math-value"><code>block math</code> or
-                <code>inline math</code></a>.
-            </li>
-            <li>
               Alignment properties:
               <code>align-content</code>, <code>justify-content</code>,
               <code>align-self</code>, <code>justify-self</code> have
@@ -1172,10 +1161,20 @@
               of a <a>math content box</a>, its <a>block size</a> is set to their sum.
             </li>
             <li>
-              The box metrics, offsets, <a>baselines</a>, <a>italic correction</a> and
+              By default,
+              the box metrics, offsets, <a>baselines</a>, <a>italic correction</a> and
               <a>top accent attachment</a> of the
               <a>content box</a>
               are set to the one calculated for the <a>math content box</a>.
+              However if a different size is specified for the
+              <a>content box</a> (via
+              <a data-xref-type="css-property">width</a>,
+              <a data-xref-type="css-property">height</a> or related
+              properties), that size is used instead and the
+              the inline-start and block-start edges of the
+              <a>math content box</a> are aligned with the ones of the
+              <a>content box</a>, unless otherwise specified in
+              a specific layout algorithm.
             </li>
             <li>
               <p>
@@ -1267,8 +1266,6 @@
             box layout and child boxes are laid out without
             any stretch size constraint.
           </p>
-          <div class="issue" data-number="75">Interpret
-            width/height/inline-size/block-size?</div>
           <div class="issue" data-number="76">Define what inline percentages resolve against</div>
           <div class="issue" data-number="77">Define what block percentages resolve against</div>
         </section>
@@ -2673,10 +2670,17 @@
               towards the <a>line-over</a> (respectively <a>line-under</a>).
             </p>
             <p>
+              The <a>math content box</a> is placed within the
+              <a>content box</a> so that their block-start edges
+              are aligned and the middles of these edges are at the same
+              position.
+            </p>
+            <p>
               The <a>inline size</a> of the fraction bar is the
-              <a>inline size</a> of the math content and its
-              <a>inline offset</a> is 0.
-              The center of the fraction bar is shifted away from the <a>alphabetic baseline</a>
+              <a>inline size</a> of the <a>content box</a> and its
+              inline-start edge is the aligned with the one the
+              <a>content box</a>.
+              The center of the fraction bar is shifted away from the <a>alphabetic baseline</a> of the <a>math content box</a>
               by a distance of <a>AxisHeight</a> towards the <a>line-over</a>.
               Its <a>block size</a> is the
               <a>fraction line thickness</a>.
@@ -2769,6 +2773,12 @@
               <code>TopShift</code> (respectively −
               <code>BottomShift</code>) towards the
               <a>line-over</a> (respectively <a>line-under</a>).
+            </p>
+            <p>
+              The <a>math content box</a> is placed within the
+              <a>content box</a> so that their block-start edges
+              are aligned and the middles of these edges are at the same
+              position.
             </p>
           </section>
         </section>
@@ -3886,6 +3896,12 @@
               the <a>ink line-descent</a> of the <a>munder base</a>'s <a>margin box</a>
               + <code>UnderShift</code>.
             </p>
+            <p>
+              The <a>math content box</a> is placed within the
+              <a>content box</a> so that their block-start edges
+              are aligned and the middles of these edges are at the same
+              position.
+            </p>
           </section>
           <section>
             <h4>Base with overscript</h4>
@@ -4042,6 +4058,12 @@
               and towards the <a>line-over</a> by a distance equal to
               the <a>ink line-ascent</a> of the base + <code>OverShift</code>.
             </p>
+            <p>
+              The <a>math content box</a> is placed within the
+              <a>content box</a> so that their block-start edges
+              are aligned and the middles of these edges are at the same
+              position.
+            </p>
           </section>
           <section>
             <h4>Base with underscript and overscript</h4>
@@ -4095,6 +4117,12 @@
               are calculated as in sections
               <a href="#base-with-underscript"></a> and
               <a href="#base-with-overscript"></a>.
+            </p>
+            <p>
+              The <a>math content box</a> is placed within the
+              <a>content box</a> so that their block-start edges
+              are aligned and the middles of these edges are at the same
+              position.
             </p>
             <div class="note">
               <p>


### PR DESCRIPTION
This commit is basically aligning on Chromium's implementation, with the following tweaks:

https://chromium-review.googlesource.com/c/chromium/src/+/4116578
https://chromium-review.googlesource.com/c/chromium/src/+/4120274
https://chromium-review.googlesource.com/c/chromium/src/+/4043023

See also https://github.com/w3c/mathml-core/issues/75#issuecomment-1354502109 for a testcase.

WPT tests will be written later.