### PR TITLE
Fix mapping of display values on non-MathML elements

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4741,8 +4741,8 @@
         </table>
         <p>
           For elements that are not <a>MathML elements</a>, if the specified
-          value of <code>display</code> is <code>inline math</code> or
-          <code>block math</code> then the computed value is
+          value of <code>display</code> is <code>block math</code> or
+          <code>inline math</code> then the computed value is
           <code>block flow</code> and <code>inline flow</code> respectively.
           For the [^mtable^] element
           the computed value is <code>block table</code> and


### PR DESCRIPTION
Previously the spec mapped inline math to block flow, which is incorrect.

The spec didn't match the tests or Chromium implementation.

cc @bkardell 