### PR TITLE
define math-auto by reference to css-text-4 for #246

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1326,7 +1326,7 @@
           <p>The layout algorithm is the same as the [^mtext^] element. The
             <a>user agent stylesheet</a>
             must contain the following property in order to implement automatic
-            italic via the text-transform value introduced in <a href="#new-text-transform-values"></a>:
+            italic via the text-transform value introduced in <a href="#math-auto-transform"></a>:
           </p>
           <pre class="css" data-include="user-agent-stylesheet/mi.css"></pre>
 
@@ -1357,7 +1357,7 @@
           <div class="example" id="mi-example">
             <p>In the following example, [^mi^] is used to render
               variables and function names. Note that per
-              <a href="#new-text-transform-values"></a> the default
+              <a href="#math-auto-transform"></a> the default
               style <code>text-transform: math-auto</code> has
               no effect on the first <code>&lt;mi&gt;</code> ("cos" is made of three characters),
               makes the second <code>&lt;mi&gt;</code> render as math italic ("c" is made of a single
@@ -4799,26 +4799,11 @@
           <img src="examples/example-display.png" alt="display example">
         </div>
       </section>
-      <section id="new-text-transform-values">
-        <h3>New <code>text-transform</code> value</h3>
+      <section id="math-auto-transform">
+        <h3>The <code>math-auto</code> transform</h3>
         <p>The <a data-xref-type="css-property">text-transform</a> property
-          from <a data-cite="CSS-TEXT-3"></a>
-          is extended with a new value:
-        </p>
-        <table class="def propdef partial" data-link-for-hint="text-transform">
-          <tbody>
-            <tr>
-              <th>Name:</th>
-              <td><a class="css" data-xref-type="css-property" id="ref-for-propdef-text-transform">text-transform</a>
-              </td>
-            </tr>
-            <tr class="value">
-              <th><a data-cite="CSS-VALUES-4#value-defs">New value:</a></th>
-              <td class="prod">math-auto</td>
-            </tr>
-          </tbody>
-        </table>
-        <p>
+          from <a data-cite="CSS-TEXT-4"></a>
+          has  a new value `math-auto`.
           On text nodes containing a single character, if the computed value
           is <code>math-auto</code> and the character is present in the
           "Original" column of <a href="#italic-mappings"></a>


### PR DESCRIPTION
As suggested in #246 this deletes the "new" definition of the `math-auto` transform and refernces the css-text-4 spec