### PR TITLE
re-arrange alphanumerics appendix

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5907,111 +5907,39 @@
         <div data-include="tables/unicode-assembly.html"></div>
       </section>
     </section>
-    <section>
+    <section class="informative">
       <h3 id="new-text-transform-mappings">Mathematical Alphanumeric Symbols</h3>
-      <p>
-        The following tables enumerate the mathematical alphanumeric symbols
+      <p>As detailed in [[xml-entity-names]] mathematical alphanumeric symbols
         with form bold, italic, fraktur, monospace, double-struck etc
-        that are available in Unicode.
-        For each of them, the character in its normal form is provided as
-        well as the difference between the code points of the transformed and
-        original characters.
-      </p>
-      <div class="note">
-        This difference can be used to simplify implementations. For example
-        for italic mappings, the code point of a uppercase latin letter is
-        increased by 0x1D3F3, the code point of a lowercase latin letter is
-        (generally) increased by 1D3ED, etc and the exceptions can be
-        handled separately.
-      </div>
-          <div class="note">
-            <p>It is sometimes needed to distinguish between
-            Chancery and Roundhand style for MATHEMATICAL SCRIPT characters.
-            These are notably used in LaTeX for the
-            <code>\mathcal</code> and <code>\mathscr</code> commands.</p>
-            <p>One way to do that is to rely on
-            Chapter 23.4 Variation Selectors of
-            Unicode which describes a way to
-            specify selection of particular glyph variants [[UNICODE]].
-            Indeed, the
-            <code>StandardizedVariants.txt</code> file from the
-            Unicode Character Database indicates that variant selectors
-            U+FE00 and U+FE01 can be used on capital script to specify
-            Chancery and Roundhand respectively.</p>
-            <p>Alternatively, some
-            mathematical fonts rely on <code>salt</code> or
-            <code>ssXY</code> properties from [[OPEN-FONT-FORMAT]]
-            to provide both styles. Page authors may use the
-            <a data-xref-type="css-property">font-variant-alternates</a> property with corresponding OpenType font features
-            to access these glyphs.</p>
-          </div>
-      <section class="informative" id="bold-script-mappings">
-        <h4><code>bold-script</code> mappings</h4>
-        <div data-include="tables/mathvariants-bold-script.html"></div>
-      </section>
-      <section class="informative" id="bold-italic-mappings">
-        <h4><code>bold-italic</code> mappings</h4>
-        <div data-include="tables/mathvariants-bold-italic.html"></div>
-      </section>
-      <section class="informative" id="tailed-mappings">
-        <h4><code>tailed</code> mappings</h4>
-        <div data-include="tables/mathvariants-tailed.html"></div>
-      </section>
-      <section class="informative" id="bold-mappings">
-        <h4><code>bold</code> mappings</h4>
-        <div data-include="tables/mathvariants-bold.html"></div>
-      </section>
-      <section class="informative" id="fraktur-mappings">
-        <h4><code>fraktur</code> mappings</h4>
-        <div data-include="tables/mathvariants-fraktur.html"></div>
-      </section>
-      <section class="informative" id="script-mappings">
-        <h4><code>script</code> mappings</h4>
-        <div data-include="tables/mathvariants-script.html"></div>
-      </section>
-      <section class="informative" id="monospace-mappings">
-        <h4><code>monospace</code> mappings</h4>
-        <div data-include="tables/mathvariants-monospace.html"></div>
-      </section>
-      <section class="informative" id="initial-mappings">
-        <h4><code>initial</code> mappings</h4>
-        <div data-include="tables/mathvariants-initial.html"></div>
-      </section>
-      <section class="informative" id="sans-serif-mappings">
-        <h4><code>sans-serif</code> mappings</h4>
-        <div data-include="tables/mathvariants-sans-serif.html"></div>
-      </section>
-      <section class="informative" id="double-struck-mappings">
-        <h4><code>double-struck</code> mappings</h4>
-        <div data-include="tables/mathvariants-double-struck.html"></div>
-      </section>
-      <section class="informative" id="looped-mappings">
-        <h4><code>looped</code> mappings</h4>
-        <div data-include="tables/mathvariants-looped.html"></div>
-      </section>
-      <section class="informative" id="stretched-mappings">
-        <h4><code>stretched</code> mappings</h4>
-        <div data-include="tables/mathvariants-stretched.html"></div>
-      </section>
-      <section class="normative" id="italic-mappings">
+        are available in Unicode.</p>
+      <p>These alphanumeric
+	symbols should be accessed using their Unicode code points.
+	It is sometimes needed to distinguish between
+        Chancery and Roundhand style for MATHEMATICAL SCRIPT characters.
+        These are notably used in LaTeX for the
+        <code>\mathcal</code> and <code>\mathscr</code> commands.
+      One way to do that is to rely on
+        Chapter 23.4 Variation Selectors of
+        Unicode which describes a way to
+        specify selection of particular glyph variants [[UNICODE]].
+        Indeed, the
+        <code>StandardizedVariants.txt</code> file from the
+        Unicode Character Database indicates that variant selectors
+        U+FE00 and U+FE01 can be used on capital script to specify
+        Chancery and Roundhand respectively.</p>
+      Alternatively, some
+        mathematical fonts rely on <code>salt</code> or
+        <code>ssXY</code> properties from [[OPEN-FONT-FORMAT]]
+        to provide both styles. Page authors may use the
+        <a data-xref-type="css-property">font-variant-alternates</a> property with corresponding OpenType font features
+        to access these glyphs.</p>
+<p>In addition, the <code>italic</code> math alphanumeric characters may be accessed as described above using the CSS
+  <code>text-transform: math-auto</code> transform which is applied by default to single character <code>&lt;mi&gt;</code> elements.
+    As a convenience the mapping to math italic is shown below.</p>
+      
+      <section  id="italic-mappings">
         <h4><code>italic</code> mappings</h4>
         <div data-include="tables/mathvariants-italic.html"></div>
-      </section>
-      <section class="informative" id="bold-fraktur-mappings">
-        <h4><code>bold-fraktur</code> mappings</h4>
-        <div data-include="tables/mathvariants-bold-fraktur.html"></div>
-      </section>
-      <section class="informative" id="sans-serif-bold-italic-mappings">
-        <h4><code>sans-serif-bold-italic</code> mappings</h4>
-        <div data-include="tables/mathvariants-sans-serif-bold-italic.html"></div>
-      </section>
-      <section class="informative" id="sans-serif-italic-mappings">
-        <h4><code>sans-serif-italic</code> mappings</h4>
-        <div data-include="tables/mathvariants-sans-serif-italic.html"></div>
-      </section>
-      <section class="informative" id="bold-sans-serif-mappings">
-        <h4><code>bold-sans-serif</code> mappings</h4>
-        <div data-include="tables/mathvariants-bold-sans-serif.html"></div>
       </section>
     </section>
     <section class="appendix informative">


### PR DESCRIPTION
As suggested in #234  this re-arranges appendix C, deleting all the tables except the one for italic.

I marked the entire appendix as informative which allowed the text to be moved out of "Notes" to normal text, otherwise it is almost all notes.

Basically it now says to use the Unicode code points referencing the working group's entities spec for what those points are without listing them here (https://w3c.github.io/xml-entities/#alphabets) and stating that the italic tranform is the css math-auto transform with its mapping copied to this appendix for convenience.
