### PR TITLE
Change animation type for CSS properties

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4914,7 +4914,7 @@
             </tr>
             <tr>
               <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a></th>
-              <td>not animatable</td>
+              <td>by computed value type</td>
             </tr>
             <tr>
               <th>Media:</th>
@@ -5012,7 +5012,7 @@
             </tr>
             <tr>
               <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type</a>:</th>
-              <td>not animatable</td>
+              <td>by computed value type</td>
             </tr>
             <tr>
               <th>Media:</th>
@@ -5102,7 +5102,7 @@
             </tr>
             <tr>
               <th><a href="https://www.w3.org/TR/web-animations/#animation-type">Animation type:</a></th>
-              <td>not animatable</td>
+              <td>by computed value type</td>
             </tr>
             <tr>
               <th>Media:</th>


### PR DESCRIPTION
Closes #293

Changes the animation type of the CSS properties from non animatable to their respective computed value. This means that `math-style` and `math-shift` will animate discretely, and `math-depth` will animate like an integer.