### PR TITLE
Clarify font-size: math procedure step

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5153,7 +5153,7 @@
               <li>Otherwise B &gt; A and set <code>InvertScaleFactor</code> to false.</li>
             </ul>
           </li>
-          <li>Let E be B - A &gt; 0.</li>
+          <li>Let E be B - A, which is positive.</li>
           <li>If the inherited <a>first available font</a> has an OpenType MATH table:
             <ul>
               <li>If A ≤ 0 and B ≥ 2 then multiply S by <a>scriptScriptPercentScaleDown</a> and


### PR DESCRIPTION
Small tweak to the `font-size: math` algorithm. I was implementing this and I was confused at first thinking that it meant that `E = (B - A) > 0`, so 1 if it was positive and 0 otherwise. This doesn't make much sense in the context (`B - A` is always positive), but I think it doesn't hurt to remove the ambiguity here.