### PR TITLE
Correct a wrong link for `form` attribute.

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1458,7 +1458,7 @@
               In the following example, the [^mo^] element
               is used for the binary operator +. Default spacing is symmetric
               around that operator. A tighter spacing is used if you rely
-              on the <a><code>form</code></a> attribute to force it to be
+              on the [^mo/form^] attribute to force it to be
               treated as a prefix operator.
               Spacing can also be specified explicitly using the
               [^mo/lspace^] and


### PR DESCRIPTION
The _form_ in the following sentence

> A tighter spacing is used if you rely on the _form_ attribute to force it to be treated as a prefix operator.

is linked to the `form` element of HTML. This PR fixes the link to the `form` attribute of MathML.
