### PR TITLE
corrections to combining characters table

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -5930,11 +5930,6 @@
           The following table gives mappings between spacing and non spacing
           characters when used in MathML accent constructs.
         </p>
-	<p>Current fonts for mathematics are inconsistent over which character
-	  is provided and for which characters the <a href="#opentype-math-table">OpenType MATH table</a>
-	  provides information to allow the construction of wide accents.
-          It is recommended that either character be accepted on input but if the current font only supports
-	  horizontal constructions for the other character that that character is used in the layout.</p>
         <div data-include="tables/combining-operators.html"></div>
       </section>
       <section class="informative">


### PR DESCRIPTION
The tables in appendix B3 show some entries with 3-digit hex such as U+02E and U+0B8 and (consequently) no comment with the unicode name as the id lookup failed.  In one case the line is duplicated with both a broken entry for U+02E followed by the correct entry for U+002E full stop

This has been corrected in the source unicode.xml at commit 

https://github.com/w3c/xml-entities/commit/ed8b732d7d38112f258e74aadecbb1e409eafdd9

and the matching entries fixed here (by hand as I see no record of the script to generate `combining-operators.html` either here or in the xml-entities repo). 

so there are no normative changes here just deleting one duplicated entry and replacing uncommented three-character hex by four character hex with a comment of the Unicode name.
