### PR TITLE
add a element to mathml-core #142

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4681,14 +4681,16 @@
             If the
             <dfn data-dfn-for="a" class="element-attr">href</dfn>
             attribute is used then the <code>&lt;a&gt;</code> element creates a hyperlink
-	    to the URL sprecifoed by the <code>href</code> attribute. The linking behavior
+	    to the URL specified by the <code>href</code> attribute. The linking behavior
 	    is as described for the <code>a</code> element in HTML.
           </p>
 
 	  <p> The layout algorithm of the <code>&lt;a&gt;</code> element
-          is the same as the <code>&lt;mrow&gt;</code> element.
+          is the same as the <code>&lt;mrow&gt;</code> element.</p>
+
+	  <div class="note">
           Note that this means that in the absence of an <code>href</code> attribute,
-	  <code>&lt;a&gt;</code> may be seen as equivalent to <code>&lt;mrow&gt;</code>.</p>
+	  <code>&lt;a&gt;</code> may be seen as equivalent to <code>&lt;mrow&gt;</code>.</div>
         </section>
       <section id="enlivening-expressions">
         <h3>Enlivening Expressions</h3>


### PR DESCRIPTION
This adds a new section describing an `<a>` element to address #142 

It has the layout rules of `mrow` and the attributes and behavior of HTML `<a>`

The exact words in particular the wording to pull in all the behaviors and accessibility/security issues of links probably needs further adjustment but if this PR could be merged sooner rather than later it would put down the intention to add linking to mathml-core and allow the mathml4 draft to have target sections to reference and polyfills and examples updated etc.

In the spec I have stated  that all attributes of html `<a>` are allowed but only highlighted `href`  so attributes such as `target` or `rel` are allowed but not described here.  We could describe (or at least list) them explicitly here if that was thought necessary although for example we don't explicitly list all the event handler attributes such as `onclick` we just reference the html spec.

