### PR TITLE
Ignore variation selectors in operator category determination

### DIFF
--- a/overview.html
+++ b/overview.html
@@ -6468,8 +6468,9 @@ mmultiscripts &gt; mprescripts ~ <span class="hljs-selector-pseudo">:nth-child</
                 <a href="#operator-dictionary-categories-values" class="fig-ref" title="Operators values for each category.The third column provides a 4bits encoding of the categorieswhere the 2 least significant bits encodes the form infix (0), prefix (1) and postfix (2).">Figure <bdi class="figno">26</bdi></a>
                 and move to the last step.</li>
               <li>If the second character is
-                U+0338 COMBINING LONG SOLIDUS OVERLAY or
-                U+20D2 COMBINING LONG VERTICAL LINE OVERLAY then replace
+                U+0338 COMBINING LONG SOLIDUS OVERLAY,
+                U+20D2 COMBINING LONG VERTICAL LINE OVERLAY,
+                or a variation selector in the range U+FE00-U+FE0F, then replace
                 <code>Content</code> with the first character.</li>
               <li>Otherwise, if <code>Content</code> it is listed in
                 <a href="#operator-dictionary-compact-special-tables"><code>Operators_2_ascii_chars</code></a> then

--- a/spec.html
+++ b/spec.html
@@ -5866,8 +5866,9 @@
                 <code>Form</code> is <code>postfix</code>, exit with category
                 <code>I</code>.</li>
               <li>If the second character is
-                U+0338 COMBINING LONG SOLIDUS OVERLAY or
-                U+20D2 COMBINING LONG VERTICAL LINE OVERLAY then replace
+                U+0338 COMBINING LONG SOLIDUS OVERLAY,
+                U+20D2 COMBINING LONG VERTICAL LINE OVERLAY,
+                or a variation selector in the range U+FE00-U+FE0F, then replace
                 <code>Content</code> with the first character and move to step
                 3.</li>
               <li>Otherwise, if <code>Content</code> is listed in


### PR DESCRIPTION
Ensures that variation sequences in <https://www.unicode.org/Public/latest/ucd/StandardizedVariants.txt> are classified properly. For example, the sequence [U+2295 CIRCLED PLUS, U+FE00] (<math><mo>⊕︀</mo></math>) should have the same lspace and rspace than plain U+2295 CIRCLED PLUS (<math><mo>⊕</mo></math>).

This does not account for the case where a variation selector is followed by U+0338 COMBINING LONG SOLIDUS OVERLAY or U+20D2 COMBINING LONG VERTICAL LINE OVERLAY (resulting in a string of length 3). Further changes would be necessary to handle that edge case.